### PR TITLE
Templating for Lawyers: fix link to Mustache's page

### DIFF
--- a/_posts/2021-03-13-Templating-for-Lawyers.md
+++ b/_posts/2021-03-13-Templating-for-Lawyers.md
@@ -14,7 +14,7 @@ Once you can read and write legal language in a computer-friendly way, the next 
 
 In techie terms, you want a "templating system", a convention for typing if-then into documents that both people and computers can understand.
 
-The system I recommend is called ["Mustache"](https://en.wikipedia.org/wiki/Mustache_(template_system)).  You can read about Mustache on [Wikipedia](https//mustache.github.io/), or even [dive in to the manual yourself](https://mustache.github.io/mustache.5.html).  But we can cover the essentials for legal drafters right here, in just a few examples.
+The system I recommend is called ["Mustache"](https://en.wikipedia.org/wiki/Mustache_(template_system)).  You can read about Mustache on [Wikipedia](https://mustache.github.io/), or even [dive in to the manual yourself](https://mustache.github.io/mustache.5.html).  But we can cover the essentials for legal drafters right here, in just a few examples.
 
 ## 80-20 Mustache for Lawyers
 


### PR DESCRIPTION
Also, I think the `"Mustache"` and `Wikipedia` links are switched, and I'm not sure if this is intentional.