### PR TITLE
Fix incorrect smart quote in title of “Time Off Summer ‘21”

### DIFF
--- a/_posts/2021-08-20-Time-Off.md
+++ b/_posts/2021-08-20-Time-Off.md
@@ -1,5 +1,5 @@
 ---
-title: Time Off Summer '21
+title: Time Off Summer ’21
 description: out of office August 29 through September 8
 date: 2021-08-20T18:36Z
 tags:


### PR DESCRIPTION
Change the straight quote in the abbreviated year “'21” to an explicit apostrophe “’21”. This prevents the blog engine from incorrectly auto-formatting “'21” as “‘21”, which contains a left single quote.

This affects the post [Time Off Summer ‘21](https://writing.kemitchell.com/2021/08/20/Time-Off.html).